### PR TITLE
Update module to allow homeTabContent without homeTab Hook

### DIFF
--- a/blocknewproducts.php
+++ b/blocknewproducts.php
@@ -1,6 +1,6 @@
 <?php
 /*
-* 2007-2016 PrestaShop
+* 2007-2019 PrestaShop
 *
 * NOTICE OF LICENSE
 *
@@ -19,7 +19,7 @@
 * needs please refer to http://www.prestashop.com for more information.
 *
 *  @author PrestaShop SA <contact@prestashop.com>
-*  @copyright  2007-2016 PrestaShop SA
+*  @copyright  2007-2019 PrestaShop SA
 *  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *  International Registered Trademark & Property of PrestaShop SA
 */
@@ -35,7 +35,7 @@ class BlockNewProducts extends Module
 	{
 		$this->name = 'blocknewproducts';
 		$this->tab = 'front_office_features';
-		$this->version = '1.10.1';
+		$this->version = '1.10.2';
 		$this->author = 'PrestaShop';
 		$this->need_instance = 0;
 
@@ -153,6 +153,9 @@ class BlockNewProducts extends Module
 	{
 		if (!$this->isCached('blocknewproducts_home.tpl', $this->getCacheId('blocknewproducts-home')))
 		{
+			if (!$this->isCached('tab.tpl', $this->getCacheId('blocknewproducts-tab')))
+				BlockNewProducts::$cache_new_products = $this->getNewProducts();
+			
 			$this->smarty->assign(array(
 				'new_products' => BlockNewProducts::$cache_new_products,
 				'mediumSize' => Image::getSize(ImageType::getFormatedName('medium')),


### PR DESCRIPTION
Support hook HomeTabContent produtcs without HomeTab Hook defined.
This will allow to have the module on hook HomeTabContent without also being on HomeTab hook.